### PR TITLE
Fixes the "unknown argument" error caused by exist_ok option in iOS 1…

### DIFF
--- a/read_from_working_copy_app.py
+++ b/read_from_working_copy_app.py
@@ -16,7 +16,8 @@ def main():
         dest_path = srce_path.split('/File Provider Storage/')[-1]
         dest_path = os.path.join(from_wc, dest_path)
         file_path, file_name = os.path.split(dest_path)
-        os.makedirs(file_path, exist_ok=True)
+        if not os.path.exists(file_path)
+            os.makedirs(file_path)
         if os.path.isdir(srce_path):
             shutil.rmtree(dest_path, ignore_errors=True)
             print(shutil.copytree(srce_path, dest_path))


### PR DESCRIPTION
When I try to use this script to pull a folder from working copy into  Pythonista on my iPad pro(10.0.1), I get an "unknown argument" error. This patch fixes this problem. Though it seems that pulling individual files still doesn't work well(invalid file_path?). 